### PR TITLE
feat: add field variants to receive data about video(s) when media type is video

### DIFF
--- a/v2/media_obj.go
+++ b/v2/media_obj.go
@@ -38,17 +38,18 @@ func mediaFieldStringArray(arr []MediaField) []string {
 
 // MediaObj refers to any image, GIF, or video attached to a Tweet
 type MediaObj struct {
-	Key              string           `json:"media_key"`
-	Type             string           `json:"type"`
-	URL              string           `json:"url"`
-	DurationMS       int              `json:"duration_ms"`
-	Height           int              `json:"height,omitempty"`
-	NonPublicMetrics *MediaMetricsObj `json:"non_public_metrics,omitempty"`
-	OrganicMetrics   *MediaMetricsObj `json:"organic_metrics,omitempty"`
-	PreviewImageURL  string           `json:"preview_image_url,omitempty"`
-	PromotedMetrics  *MediaMetricsObj `json:"promoted_metrics,omitempty"`
-	PublicMetrics    *MediaMetricsObj `json:"public_metrics,omitempty"`
-	Width            int              `json:"width,omitempty"`
+	Key              string             `json:"media_key"`
+	Type             string             `json:"type"`
+	URL              string             `json:"url"`
+	DurationMS       int                `json:"duration_ms"`
+	Height           int                `json:"height,omitempty"`
+	NonPublicMetrics *MediaMetricsObj   `json:"non_public_metrics,omitempty"`
+	OrganicMetrics   *MediaMetricsObj   `json:"organic_metrics,omitempty"`
+	PreviewImageURL  string             `json:"preview_image_url,omitempty"`
+	PromotedMetrics  *MediaMetricsObj   `json:"promoted_metrics,omitempty"`
+	PublicMetrics    *MediaMetricsObj   `json:"public_metrics,omitempty"`
+	Width            int                `json:"width,omitempty"`
+	Variants         []*MediaVariantObj `json:"variants,omitempty"`
 }
 
 // MediaMetricsObj engagement metrics for the media content at the time of the request
@@ -59,4 +60,10 @@ type MediaMetricsObj struct {
 	Playback50  int `json:"playback_50_count"`
 	Playback75  int `json:"playback_75_count"`
 	Views       int `json:"view_count"`
+}
+
+type MediaVariantObj struct {
+	BitRate     int    `json:"bit_rate"`
+	ContentType string `json:"content_type"`
+	Url         string `json:"url"`
 }

--- a/v2/media_obj.go
+++ b/v2/media_obj.go
@@ -26,6 +26,8 @@ const (
 	MediaFieldOrganicMetrics MediaField = "organic_metrics"
 	// MediaFieldPromotedMetrics is the URL to the static placeholder preview of this content.
 	MediaFieldPromotedMetrics MediaField = "promoted_metrics"
+	// MediaFieldVariants contains multiple the display or playback variants of media object, with different resolutions or formats
+	MediaFieldVariants MediaField = "variants"
 )
 
 func mediaFieldStringArray(arr []MediaField) []string {


### PR DESCRIPTION
- An example can be obtained from this tweet ID: 1544404667718926338;
- We are using this struct when do recent search API;